### PR TITLE
Peak fndr

### DIFF
--- a/heartpy/datautils.py
+++ b/heartpy/datautils.py
@@ -279,14 +279,19 @@ def rolling_mean(data, windowsize, sample_rate):
            514.45333333, 514.45333333, 514.45333333, 514.45333333,
            514.48      , 514.52      ])
     '''
-    avg_hr = (np.mean(data))
+
+    # calculate rolling mean
     data_arr = np.array(data)
     rol_mean = np.mean(_sliding_window(data_arr, int(windowsize*sample_rate)), axis=1)
-    missing_vals = np.array([avg_hr for i in range(0, int(abs(len(data_arr) - len(rol_mean))/2))])
-    rol_mean = np.insert(rol_mean, 0, missing_vals)
-    rol_mean = np.append(rol_mean, missing_vals)
 
-    #only to catch length errors that sometimes unexplicably occur. 
+    # need to fill 1/2 windowsize gap at the start and end
+    n_missvals = int(abs(len(data_arr) - len(rol_mean))/2)
+    missvals_a = np.array([rol_mean[0]]*n_missvals)
+    missvals_b = np.array([rol_mean[-1]]*n_missvals)
+
+    rol_mean = np.concatenate((missvals_a, rol_mean, missvals_b))
+
+    #only to catch length errors that sometimes unexplicably occur.
     ##Generally not executed, excluded from testing and coverage
     if len(rol_mean) != len(data): # pragma: no cover
         lendiff = len(rol_mean) - len(data)

--- a/heartpy/datautils.py
+++ b/heartpy/datautils.py
@@ -19,7 +19,7 @@ __all__ = ['get_data',
            'load_exampledata']
 
 
-def get_data(filename, delim=',', column_name='None', encoding=None, 
+def get_data(filename, delim=',', column_name='None', encoding=None,
              ignore_extension=False):
     '''load data from file
 
@@ -107,7 +107,7 @@ def get_data(filename, delim=',', column_name='None', encoding=None,
                 hrdata = hrdata[column_name]
             except Exception as error:
                 raise LookupError('\nError loading column "%s" from file "%s". \
-Is column name specified correctly?\n The following error was provided: %s' 
+Is column name specified correctly?\n The following error was provided: %s'
                                  %(column_name, filename, error))
         elif column_name == 'None':
             hrdata = np.genfromtxt(filename, delimiter=delim, dtype=np.float64)
@@ -128,7 +128,7 @@ Is column name specified correctly?\n The following error was provided: %s'
                     hrdata = hrdata[column_name]
                 except Exception as error:
                     raise LookupError('\nError loading column "%s" from file "%s". \
-Is column name specified correctly?\n' 
+Is column name specified correctly?\n'
                                       %(column_name, filename))
             elif column_name == 'None': # pragma: no cover
                 hrdata = np.genfromtxt(filename, delimiter=delim, dtype=np.float64)
@@ -137,7 +137,7 @@ Is column name specified correctly?\n'
                                   %(column_name, filename))
         else:
             raise IncorrectFileType('unknown file format')
-            return None 
+            return None
     return hrdata
 
 
@@ -155,13 +155,13 @@ def get_samplerate_mstimer(timerdata):
     -------
     out : float
         the sample rate as determined from the timer sequence provided
-        
+
     Examples
     --------
     first we load a provided example dataset
 
     >>> data, timer = load_exampledata(example = 1)
-    
+
     since it's a timer that counts miliseconds, we use this function.
     Let's also round to three decimals
 
@@ -258,8 +258,8 @@ def rolling_mean(data, windowsize, sample_rate):
     data : 1-dimensional numpy array or list
         sequence containing data over which rolling mean is to be computed
 
-    windowsize : int or float 
-        the window size to use, in seconds 
+    windowsize : int or float
+        the window size to use, in seconds
         calculated as windowsize * sample_rate
 
     sample_rate : int or float
@@ -293,7 +293,7 @@ def rolling_mean(data, windowsize, sample_rate):
         if lendiff < 0:
             rol_mean = np.append(rol_mean, 0)
         else:
-            rol_mean = rol_mean[:-1]            
+            rol_mean = rol_mean[:-1]
     return rol_mean
 
 
@@ -306,7 +306,7 @@ def outliers_iqr_method(hrvalues):
 
     Parameters
     ----------
-    hrvalues : 1-d numpy array or list 
+    hrvalues : 1-d numpy array or list
         sequence of values, from which outliers need to be identified
 
     Returns
@@ -345,7 +345,7 @@ def outliers_modified_z(hrvalues):
 
     Parameters
     ----------
-    hrvalues : 1-d numpy array or list 
+    hrvalues : 1-d numpy array or list
         sequence of values, from which outliers need to be identified
 
     Returns
@@ -381,7 +381,7 @@ def MAD(data):
 
     Function that compute median absolute deviation of data slice
     See: https://en.wikipedia.org/wiki/Median_absolute_deviation
-    
+
     Parameters
     ----------
     data : 1-dimensional numpy array or list
@@ -444,7 +444,7 @@ def load_exampledata(example=0):
     '''
 
     timer = []
-    
+
     if example == 0:
         path = path = 'data/data.csv'
         filepath = resource_filename(__name__, path)

--- a/heartpy/heartpy.py
+++ b/heartpy/heartpy.py
@@ -76,8 +76,8 @@ def process(hrdata, sample_rate, windowsize=0.75, report_time=False,
         default : 0.75
 
     report_time : bool
-        whether to report total processing time of algorithm 
-        default : True
+        whether to report total processing time of algorithm
+        default : False
 
     calc_freq : bool
         whether to compute frequency domain measurements 
@@ -90,11 +90,11 @@ def process(hrdata, sample_rate, windowsize=0.75, report_time=False,
 
     freq_square : bool
         whether to square the power spectrum returned when computing frequency measures
-        default : true
-
-    interp_clipping : bool 
-        whether to detect and interpolate clipping segments of the signal 
         default : True
+
+    interp_clipping : bool
+        whether to detect and interpolate clipping segments of the signal
+        default : False
 
     clipping_scale : bool
         whether to scale the data prior to clipping detection. Can correct errors 
@@ -130,7 +130,7 @@ def process(hrdata, sample_rate, windowsize=0.75, report_time=False,
     high_precision : bool 
         whether to estimate peak positions by upsampling signal to sample rate
         as specified in high_precision_fs
-        default : false
+        default : False
 
     high_precision_fs : int or float 
         the sample rate to which to upsample for more accurate peak position estimation 
@@ -138,11 +138,11 @@ def process(hrdata, sample_rate, windowsize=0.75, report_time=False,
 
     breathing_method : str
         method to use for estimating breathing rate, should be 'welch' or 'fft'
-        default : fft
+        default : welch
 
     clean_rr : bool
         if true, the RR_list is further cleaned with an outlier rejection pass
-        default : false
+        default : False
 
     clean_rr_method: str
         how to find and reject outliers. Available methods are ' quotient-filter', 
@@ -155,7 +155,7 @@ def process(hrdata, sample_rate, windowsize=0.75, report_time=False,
 
     working_data : dict
         dictionary object that contains all heartpy's working data (temp) objects.
-        will be created if not passed to function
+        Will be created if not passed to function.
 
     Returns
     -------

--- a/heartpy/heartpy.py
+++ b/heartpy/heartpy.py
@@ -268,6 +268,11 @@ include an index column?'
         hrdata = enhance_peaks(hrdata)
         hrdata = hampel_correcter(hrdata, sample_rate)
 
+    # check that the data has positive baseline for the moving average algorithm to work
+    bl_val = np.percentile(hrdata, 0.1)
+    if bl_val < 0:
+        hrdata = hrdata + abs(bl_val)
+
     working_data['hr'] = hrdata
     rol_mean = rolling_mean(hrdata, windowsize, sample_rate)
 
@@ -279,6 +284,7 @@ include an index column?'
                                          desired_sample_rate=high_precision_fs, working_data=working_data)
 
     working_data = calc_rr(working_data['peaklist'], sample_rate, working_data=working_data)
+
     working_data = check_peaks(working_data['RR_list'], working_data['peaklist'], working_data['ybeat'],
                                reject_segmentwise, working_data=working_data)
 
@@ -308,6 +314,7 @@ include an index column?'
             print('\nFinished in %.8s sec' %(time.perf_counter()-t1))
         else:
             print('\nFinished in %.8s sec' %(time.clock()-t1))
+
     return working_data, measures
 
 
@@ -504,7 +511,7 @@ def process_rr(rr_list, threshold_rr=False, clean_rr=False,
         default : false
 
     clean_rr_method: str
-        how to find and reject outliers. Available methods are ' quotient-filter',
+        how to find and reject outliers. Available methods are 'quotient-filter',
         'iqr' (interquartile range), and 'z-score'.
         default : 'quotient-filter'
 

--- a/heartpy/heartpy.py
+++ b/heartpy/heartpy.py
@@ -80,7 +80,7 @@ def process(hrdata, sample_rate, windowsize=0.75, report_time=False,
         default : True
 
     calc_freq : bool
-        whether to compute time-series measurements 
+        whether to compute frequency domain measurements 
         default : False
 
     freq_method : str

--- a/heartpy/heartpy.py
+++ b/heartpy/heartpy.py
@@ -52,19 +52,19 @@ __all__ = ['enhance_peaks',
            'run_tests']
 
 
-def process(hrdata, sample_rate, windowsize=0.75, report_time=False, 
+def process(hrdata, sample_rate, windowsize=0.75, report_time=False,
             calc_freq=False, freq_method='welch', freq_square=True,
-            interp_clipping=False, clipping_scale=False, interp_threshold=1020, 
-            hampel_correct=False, bpmmin=40, bpmmax=180, reject_segmentwise=False, 
+            interp_clipping=False, clipping_scale=False, interp_threshold=1020,
+            hampel_correct=False, bpmmin=40, bpmmax=180, reject_segmentwise=False,
             high_precision=False, high_precision_fs=1000.0, breathing_method='welch',
             clean_rr=False, clean_rr_method='quotient-filter', measures=None, working_data=None):
     '''processes passed heart rate data.
-    
+
     Processes the passed heart rate data. Returns measures{} dict containing results.
 
     Parameters
     ----------
-    hrdata : 1d array or list 
+    hrdata : 1d array or list
         array or list containing heart rate data to be analysed
 
     sample_rate : int or float
@@ -80,12 +80,12 @@ def process(hrdata, sample_rate, windowsize=0.75, report_time=False,
         default : False
 
     calc_freq : bool
-        whether to compute frequency domain measurements 
+        whether to compute frequency domain measurements
         default : False
 
     freq_method : str
-        method used to extract the frequency spectrum. Available: 'fft' (Fourier Analysis), 
-        'periodogram', and 'welch' (Welch's method). 
+        method used to extract the frequency spectrum. Available: 'fft' (Fourier Analysis),
+        'periodogram', and 'welch' (Welch's method).
         default : 'welch'
 
     freq_square : bool
@@ -97,24 +97,24 @@ def process(hrdata, sample_rate, windowsize=0.75, report_time=False,
         default : False
 
     clipping_scale : bool
-        whether to scale the data prior to clipping detection. Can correct errors 
-        if signal amplitude has been affected after digitization (for example through 
-        filtering). Not recommended by default. 
+        whether to scale the data prior to clipping detection. Can correct errors
+        if signal amplitude has been affected after digitization (for example through
+        filtering). Not recommended by default.
         default : False
 
     interp_threshold : int or float
         threshold to use to detect clipping segments. Recommended to be a few
         datapoints below the sensor or ADC's maximum value (to account for
-        slight data line noise). 
+        slight data line noise).
         default : 1020, 4 below max of 1024 for 10-bit ADC
 
-    hampel_correct : bool 
+    hampel_correct : bool
         whether to reduce noisy segments using large median filter. Disabled by
         default due to computational complexity and (small) distortions induced
         into output measures. Generally it is not necessary.
         default : False
 
-    bpmmin : int or float 
+    bpmmin : int or float
         minimum value to see as likely for BPM when fitting peaks
         default : 40
 
@@ -123,17 +123,17 @@ def process(hrdata, sample_rate, windowsize=0.75, report_time=False,
         default : 180
 
     reject_segmentwise : bool
-        whether to reject segments with more than 30% rejected beats. 
-        By default looks at segments of 10 beats at a time. 
+        whether to reject segments with more than 30% rejected beats.
+        By default looks at segments of 10 beats at a time.
         default : False
 
-    high_precision : bool 
+    high_precision : bool
         whether to estimate peak positions by upsampling signal to sample rate
         as specified in high_precision_fs
         default : False
 
-    high_precision_fs : int or float 
-        the sample rate to which to upsample for more accurate peak position estimation 
+    high_precision_fs : int or float
+        the sample rate to which to upsample for more accurate peak position estimation
         default : 1000 Hz
 
     breathing_method : str
@@ -145,7 +145,7 @@ def process(hrdata, sample_rate, windowsize=0.75, report_time=False,
         default : False
 
     clean_rr_method: str
-        how to find and reject outliers. Available methods are ' quotient-filter', 
+        how to find and reject outliers. Available methods are ' quotient-filter',
         'iqr' (interquartile range), and 'z-score'.
         default : 'quotient-filter'
 
@@ -161,7 +161,7 @@ def process(hrdata, sample_rate, windowsize=0.75, report_time=False,
     -------
     working_data : dict
         dictionary object used to store temporary values.
-    
+
     measures : dict
         dictionary object used by heartpy to store computed measures.
 
@@ -171,7 +171,7 @@ def process(hrdata, sample_rate, windowsize=0.75, report_time=False,
     provided two examples of how to approach heart rate analysis.
 
     The first example contains noisy sections and comes with a timer column that
-    counts miliseconds since start of recording. 
+    counts miliseconds since start of recording.
 
     >>> import heartpy as hp
     >>> data, timer = hp.load_exampledata(1)
@@ -181,7 +181,7 @@ def process(hrdata, sample_rate, windowsize=0.75, report_time=False,
 
     The sample rate is one of the most important characteristics during the
     heart rate analysis, as all measures are relative to this.
-    
+
     With all data loaded and the sample rate determined, analysis is now easy:
 
     >>> wd, m = hp.process(data, sample_rate = sample_rate)
@@ -210,8 +210,8 @@ def process(hrdata, sample_rate, windowsize=0.75, report_time=False,
     In this segment the clipping is visible around amplitude 980 so let's set that as well:
 
     >>> data, timer = hp.load_exampledata(1)
-    >>> sample_rate = hp.get_samplerate_mstimer(timer)  
-    >>> wd, m = hp.process(data, sample_rate = sample_rate, calc_freq = True, 
+    >>> sample_rate = hp.get_samplerate_mstimer(timer)
+    >>> wd, m = hp.process(data, sample_rate = sample_rate, calc_freq = True,
     ... interp_clipping = True, interp_threshold = 975)
     >>> '%.3f' %m['bpm']
     '62.376'
@@ -225,19 +225,19 @@ def process(hrdata, sample_rate, windowsize=0.75, report_time=False,
     Use high_precision_fs to set the virtual sample rate to which the peak
     will be upsampled (e.g. 1000Hz gives an estimated 1ms accuracy)
 
-    >>> wd, m = hp.process(data, sample_rate = sample_rate, calc_freq = True, 
+    >>> wd, m = hp.process(data, sample_rate = sample_rate, calc_freq = True,
     ... high_precision = True, high_precision_fs = 1000.0)
 
     Finally setting reject_segmentwise will reject segments with more than 30% rejected beats
     See check_binary_quality in the peakdetection.py module.
 
-    >>> wd, m = hp.process(data, sample_rate = sample_rate, calc_freq = True, 
+    >>> wd, m = hp.process(data, sample_rate = sample_rate, calc_freq = True,
     ... reject_segmentwise = True)
 
     Final test for code coverage, let's turn all bells and whistles on that haven't been
     tested yet
 
-    >>> wd, m = hp.process(data, sample_rate = 100.0, calc_freq = True, 
+    >>> wd, m = hp.process(data, sample_rate = 100.0, calc_freq = True,
     ... interp_clipping = True, clipping_scale = True, reject_segmentwise = True, clean_rr = True)
     '''
 
@@ -273,9 +273,9 @@ include an index column?'
 
     working_data = fit_peaks(hrdata, rol_mean, sample_rate, bpmmin=bpmmin,
                              bpmmax=bpmmax, working_data=working_data)
-    
+
     if high_precision:
-        working_data = interpolate_peaks(hrdata, working_data['peaklist'], sample_rate=sample_rate, 
+        working_data = interpolate_peaks(hrdata, working_data['peaklist'], sample_rate=sample_rate,
                                          desired_sample_rate=high_precision_fs, working_data=working_data)
 
     working_data = calc_rr(working_data['peaklist'], sample_rate, working_data=working_data)
@@ -286,14 +286,14 @@ include an index column?'
         working_data = clean_rr_intervals(working_data, method = clean_rr_method)
 
     working_data, measures = calc_ts_measures(working_data['RR_list_cor'], working_data['RR_diff'],
-                                              working_data['RR_sqdiff'], measures=measures, 
+                                              working_data['RR_sqdiff'], measures=measures,
                                               working_data=working_data)
-    
+
     measures = calc_poincare(working_data['RR_list'], working_data['RR_masklist'], measures = measures,
                              working_data = working_data)
 
     try:
-        measures, working_data = calc_breathing(working_data['RR_list_cor'], method=breathing_method, 
+        measures, working_data = calc_breathing(working_data['RR_list_cor'], method=breathing_method,
                                                 measures=measures, working_data=working_data)
     except:
         measures['breathingrate'] = np.nan
@@ -301,7 +301,7 @@ include an index column?'
     if calc_freq:
         working_data, measures = calc_fd_measures(method=freq_method, measures=measures,
                                                   working_data = working_data)
-    
+
     #report time if requested. Exclude from tests, output is untestable.
     if report_time: # pragma: no cover
         if sys.version_info[0] >= 3 and sys.version_info[1] >= 3:
@@ -316,13 +316,13 @@ def process_segmentwise(hrdata, sample_rate, segment_width=120, segment_overlap=
                         mode='full', **kwargs):
     '''processes passed heart rate data with a windowed function
 
-    Analyses a long heart rate data array by running a moving window 
+    Analyses a long heart rate data array by running a moving window
     over the data, computing measures in each iteration. Both the window width
     and the overlap with the previous window location are settable.
 
     Parameters
     ----------
-    hrdata : 1d array or list 
+    hrdata : 1d array or list
         array or list containing heart rate data to be analysed
 
     sample_rate : int or float
@@ -339,8 +339,8 @@ def process_segmentwise(hrdata, sample_rate, segment_width=120, segment_overlap=
 
     segment_min_size : int
         often a tail end of the data remains after segmenting into segments.
-        segment_min_size indicates the minimum length (in seconds) the tail 
-        end needs  to be in order to be included in analysis. It is discarded 
+        segment_min_size indicates the minimum length (in seconds) the tail
+        end needs  to be in order to be included in analysis. It is discarded
         if it's shorter.
         default : 20
 
@@ -359,12 +359,12 @@ def process_segmentwise(hrdata, sample_rate, segment_width=120, segment_overlap=
     ------------------
     hrdata -- 1-dimensional numpy array or list containing heart rate data
     sample_rate -- the sample rate of the heart rate data
-    segment_width -- the width of the segment, in seconds, within which all measures 
+    segment_width -- the width of the segment, in seconds, within which all measures
                      will be computed.
-    segment_overlap -- the fraction of overlap of adjacent segments, 
+    segment_overlap -- the fraction of overlap of adjacent segments,
                        needs to be 0 <= segment_overlap < 1
     segment_min_size -- After segmenting the data, a tail end will likely remain that is shorter than the specified
-                        segment_size. segment_min_size sets the minimum size for the last segment of the 
+                        segment_size. segment_min_size sets the minimum size for the last segment of the
                         generated series of segments to still be included. Default = 20.
     replace_outliers -- bool, whether to replace outliers (likely caused by peak fitting
                         errors on one or more segments) with the median.
@@ -375,10 +375,10 @@ def process_segmentwise(hrdata, sample_rate, segment_width=120, segment_overlap=
     -------
     working_data : dict
         dictionary object used to store temporary values.
-    
+
     measures : dict
         dictionary object used by heartpy to store computed measures.
-        
+
     Examples
     --------
     Given one of the included example datasets we can demonstrate this function:
@@ -400,13 +400,13 @@ def process_segmentwise(hrdata, sample_rate, segment_width=120, segment_overlap=
     to compute measures over each segment. Useful for speed ups, but typically
     the full mode has better results.
 
-    >>> wd, m = hp.process_segmentwise(data, sample_rate, segment_width=120, segment_overlap=0.5, 
+    >>> wd, m = hp.process_segmentwise(data, sample_rate, segment_width=120, segment_overlap=0.5,
     ... mode = 'fast', replace_outliers = True)
 
-    You can specify the outlier detection method ('iqr' - interquartile range, or 'z-score' for 
+    You can specify the outlier detection method ('iqr' - interquartile range, or 'z-score' for
     modified z-score approach).
-    
-    >>> wd, m = hp.process_segmentwise(data, sample_rate, segment_width=120, segment_overlap=0.5, 
+
+    >>> wd, m = hp.process_segmentwise(data, sample_rate, segment_width=120, segment_overlap=0.5,
     ... mode = 'fast', replace_outliers = True, outlier_method = 'z-score')
 
     '''
@@ -461,28 +461,28 @@ use either \'iqr\' or \'z-score\''
     if replace_outliers:
         if outlier_method.lower() == 'iqr':
             for k in s_measures.keys():
-                if k not in ['nn20', 'nn50', 'interp_rr_function', 
+                if k not in ['nn20', 'nn50', 'interp_rr_function',
                              'interp_rr_linspace', 'segment_indices']: #skip these measures
                     s_measures[k], _ = outliers_iqr_method(s_measures[k])
         elif outlier_method.lower() == 'z-score':
             for k in s_measures.keys():
-                if k not in ['nn20', 'nn50', 'interp_rr_function', 
+                if k not in ['nn20', 'nn50', 'interp_rr_function',
                              'interp_rr_linspace', 'segment_indices']: #skip these measures
                     s_measures[k], _ = outliers_modified_z(s_measures[k])
 
     return s_working_data, s_measures
 
 
-def process_rr(rr_list, threshold_rr=False, clean_rr=False, 
-               clean_rr_method='quotient-filter', calc_freq=False, 
-               freq_method='welch', square_spectrum=True, 
+def process_rr(rr_list, threshold_rr=False, clean_rr=False,
+               clean_rr_method='quotient-filter', calc_freq=False,
+               freq_method='welch', square_spectrum=True,
                breathing_method='welch', measures={}, working_data={}):
     '''process rr-list
 
     Function that takes and processes a list of peak-peak intervals (tachogram).
     Computes all measures as computed by the regular process() function, and
     sets up all dicts required for plotting poincare plots.
-    
+
     Note: This method assumes ms-based tachogram
 
     Several filtering methods are available as well.
@@ -495,7 +495,7 @@ def process_rr(rr_list, threshold_rr=False, clean_rr=False,
     threshold_rr : bool
         if true, the peak-peak intervals are cleaned using a threshold filter, which
         rejects all intervals that differ 30% from the mean peak-peak interval, with
-        a minimum of 300ms. 
+        a minimum of 300ms.
         default : false
 
     clean_rr : bool
@@ -504,17 +504,17 @@ def process_rr(rr_list, threshold_rr=False, clean_rr=False,
         default : false
 
     clean_rr_method: str
-        how to find and reject outliers. Available methods are ' quotient-filter', 
+        how to find and reject outliers. Available methods are ' quotient-filter',
         'iqr' (interquartile range), and 'z-score'.
         default : 'quotient-filter'
 
     calc_freq : bool
-        whether to compute time-series measurements 
+        whether to compute time-series measurements
         default : False
 
     freq_method : str
-        method used to extract the frequency spectrum. Available: 'fft' (Fourier Analysis), 
-        'periodogram', and 'welch' (Welch's method). 
+        method used to extract the frequency spectrum. Available: 'fft' (Fourier Analysis),
+        'periodogram', and 'welch' (Welch's method).
         default : 'welch'
 
     square_spectrum : bool
@@ -533,7 +533,7 @@ def process_rr(rr_list, threshold_rr=False, clean_rr=False,
     -------
     working_data : dict
         dictionary object used to store temporary values.
-    
+
     measures : dict
         dictionary object used by heartpy to store computed measures.
 
@@ -588,20 +588,20 @@ def process_rr(rr_list, threshold_rr=False, clean_rr=False,
         rr_sqdiff = np.power(rr_diff, 2)
 
     #compute ts measures
-    working_data, measures = calc_ts_measures(rr_list = working_data['RR_list_cor'], rr_diff = rr_diff, 
-                                              rr_sqdiff = rr_sqdiff, measures = measures, 
+    working_data, measures = calc_ts_measures(rr_list = working_data['RR_list_cor'], rr_diff = rr_diff,
+                                              rr_sqdiff = rr_sqdiff, measures = measures,
                                               working_data = working_data)
 
-    measures = calc_poincare(rr_list = working_data['RR_list'], rr_mask = working_data['RR_masklist'], 
+    measures = calc_poincare(rr_list = working_data['RR_list'], rr_mask = working_data['RR_masklist'],
                              measures = measures, working_data = working_data)
     if calc_freq:
         #compute freq measures
         working_data, measures = calc_fd_measures(method = freq_method, square_spectrum = square_spectrum,
                                                   measures = measures, working_data = working_data)
-        
+
     #compute breathing
     try:
-        measures, working_data = calc_breathing(working_data['RR_list_cor'], method = breathing_method, 
+        measures, working_data = calc_breathing(working_data['RR_list_cor'], method = breathing_method,
                                                 measures=measures, working_data=working_data)
     except:
         measures['breathingrate'] = np.nan
@@ -616,7 +616,7 @@ def run_tests(verbose=0):
 
     from . import analysis, datautils, filtering, peakdetection, preprocessing, visualizeutils, config
     import doctest
-    
+
     succeeded = 0
 
     print('testing config')
@@ -630,7 +630,7 @@ def run_tests(verbose=0):
     if results.failed == 0: # pragma: no cover
         print('success!')
         succeeded += 1
-        
+
     print('testing datautils')
     results = doctest.testmod(datautils, verbose=verbose)
     if results.failed == 0: # pragma: no cover
@@ -640,7 +640,7 @@ def run_tests(verbose=0):
     print('testing filtering')
     results = doctest.testmod(filtering, verbose=verbose)
     if results.failed == 0: # pragma: no cover
-        print('success!') 
+        print('success!')
         succeeded += 1
 
     print('testing peakdetection')

--- a/heartpy/peakdetection.py
+++ b/heartpy/peakdetection.py
@@ -7,7 +7,6 @@ from scipy.signal import resample
 
 from .analysis import calc_rr, update_rr
 from .exceptions import BadSignalWarning
-from .filtering import quotient_filter
 
 
 __all__ = ['make_windows',
@@ -306,8 +305,7 @@ outside of bpmmin<->bpmmax constraints\n- no detectable heart rate present in si
 rate data, consider filtering and/or scaling first.\n----------------\n')
 
 
-def check_peaks(rr_arr, peaklist, ybeat, quotient_filter=False, reject_segmentwise=False, 
-                working_data={}):
+def check_peaks(rr_arr, peaklist, ybeat, reject_segmentwise=False, working_data={}):
     '''find anomalous peaks.
 
     Funcion that checks peaks for outliers based on anomalous peak-peak distances and corrects

--- a/heartpy/peakdetection.py
+++ b/heartpy/peakdetection.py
@@ -22,29 +22,29 @@ __all__ = ['make_windows',
 def make_windows(data, sample_rate, windowsize=120, overlap=0, min_size=20):
     '''slices data into windows
 
-    Funcion that slices data into windows for concurrent analysis. 
+    Funcion that slices data into windows for concurrent analysis.
     Used by process_segmentwise wrapper function.
-    
+
     Parameters
     ----------
-    data : 1-d array 
+    data : 1-d array
         array containing heart rate sensor data
 
     sample_rate : int or float
         sample rate of the data stream in 'data'
 
-    windowsize : int 
+    windowsize : int
         size of the window that is sliced in seconds
 
     overlap : float
         fraction of overlap between two adjacent windows: 0 <= float < 1.0
 
-    min_size : int 
+    min_size : int
         the minimum size for the last (partial) window to be included. Very short windows
-        might not stable for peak fitting, especially when significant noise is present. 
-        Slightly longer windows are likely stable but don't make much sense from a 
+        might not stable for peak fitting, especially when significant noise is present.
+        Slightly longer windows are likely stable but don't make much sense from a
         signal analysis perspective.
-    
+
     Returns
     -------
     out : array
@@ -56,7 +56,7 @@ def make_windows(data, sample_rate, windowsize=120, overlap=0, min_size=20):
 
     >>> import heartpy as hp
     >>> data, _ = hp.load_exampledata(1)
-    
+
     We can split the data into windows:
 
     >>> indices = make_windows(data, 100.0, windowsize = 30, overlap = 0.5, min_size = 20)
@@ -72,24 +72,24 @@ def make_windows(data, sample_rate, windowsize=120, overlap=0, min_size=20):
     stepsize = (1 - overlap) * window
     start = 0
     end = window
-    
+
     slices = []
     while end < len(data):
         slices.append((start, end))
         start += stepsize
         end += stepsize
-    
-    if min_size == -1: 
+
+    if min_size == -1:
         slices[-1] = (slices[-1][0], len(data))
     elif (ln - start) / sample_rate >= min_size:
         slices.append((start, ln))
-        
+
     return np.array(slices, dtype=np.int32)
 
 
 def append_dict(dict_obj, measure_key, measure_value):
     '''appends data to keyed dict.
-    
+
     Function that appends key to continuous dict, creates if doesn't exist. EAFP
 
     Parameters
@@ -97,9 +97,9 @@ def append_dict(dict_obj, measure_key, measure_value):
     dict_obj : dict
         dictionary object that contains continuous output measures
 
-    measure_key : str 
+    measure_key : str
         key for the measure to be stored in continuous_dict
-    
+
     measure_value : any data container
         value to be appended to dictionary
 
@@ -126,7 +126,7 @@ def append_dict(dict_obj, measure_key, measure_value):
     >>> example = append_dict(example, 'different_key', 'hello there!')
     >>> sorted(example.keys())
     ['call', 'different_key']
-    ''' 
+    '''
     try:
         dict_obj[measure_key].append(measure_value)
     except KeyError:
@@ -141,10 +141,10 @@ def detect_peaks(hrdata, rol_mean, ma_perc, sample_rate, update_dict=True, worki
 
     Parameters
     ----------
-    hr data : 1-d numpy array or list 
+    hr data : 1-d numpy array or list
         array or list containing the heart rate data
 
-    rol_mean : 1-d numpy array 
+    rol_mean : 1-d numpy array
         array containing the rolling mean of the heart rate signal
 
     ma_perc : int or float
@@ -156,7 +156,7 @@ def detect_peaks(hrdata, rol_mean, ma_perc, sample_rate, update_dict=True, worki
 
     update_dict : bool
         whether to update the peak information in the module's data structure
-        Settable to False to allow this function to be re-used for example by 
+        Settable to False to allow this function to be re-used for example by
         the breath analysis module.
         default : True
 
@@ -215,26 +215,26 @@ def detect_peaks(hrdata, rol_mean, ma_perc, sample_rate, update_dict=True, worki
 def fit_peaks(hrdata, rol_mean, sample_rate, bpmmin=40, bpmmax=180, working_data={}):
     '''optimize for best peak detection
 
-    Function that runs fitting with varying peak detection thresholds given a 
+    Function that runs fitting with varying peak detection thresholds given a
     heart rate signal.
-    
+
     Parameters
     ----------
-    hrdata : 1d array or list 
+    hrdata : 1d array or list
         array or list containing the heart rate data
 
-    rol_mean : 1-d array 
+    rol_mean : 1-d array
         array containing the rolling mean of the heart rate signal
 
     sample_rate : int or float
         the sample rate of the data set
 
     bpmmin : int
-        minimum value of bpm to see as likely 
+        minimum value of bpm to see as likely
         default : 40
 
-    bpmmax : int 
-        maximum value of bpm to see as likely 
+    bpmmax : int
+        maximum value of bpm to see as likely
         default : 180
 
     Returns
@@ -246,7 +246,7 @@ def fit_peaks(hrdata, rol_mean, sample_rate, bpmmin=40, bpmmax=180, working_data
     Examples
     --------
     Part of peak detection pipeline. Uses moving average as a peak detection
-    threshold and rises it stepwise. Determines best fit by minimising 
+    threshold and rises it stepwise. Determines best fit by minimising
     standard deviation of peak-peak distances as well as getting a bpm that
     lies within the expected range.
 
@@ -268,7 +268,7 @@ def fit_peaks(hrdata, rol_mean, sample_rate, bpmmin=40, bpmmax=180, working_data
 
     This indicates the best fit can be obtained by raising the moving average
     with 20%.
-    
+
     The results of the peak detection using these parameters are included too.
     To illustrate, these are the first five detected peaks:
 
@@ -284,7 +284,7 @@ def fit_peaks(hrdata, rol_mean, sample_rate, bpmmin=40, bpmmax=180, working_data
     rrsd = []
     valid_ma = []
     for ma_perc in ma_perc_list:
-        working_data = detect_peaks(hrdata, rol_mean, ma_perc, sample_rate, 
+        working_data = detect_peaks(hrdata, rol_mean, ma_perc, sample_rate,
                                     update_dict=True, working_data=working_data)
         bpm = ((len(working_data['peaklist'])/(len(hrdata)/sample_rate))*60)
         rrsd.append([working_data['rrsd'], bpm, ma_perc])
@@ -295,7 +295,7 @@ def fit_peaks(hrdata, rol_mean, sample_rate, bpmmin=40, bpmmax=180, working_data
 
     if len(valid_ma) > 0:
         working_data['best'] = min(valid_ma, key=lambda t: t[0])[1]
-        working_data = detect_peaks(hrdata, rol_mean, min(valid_ma, key=lambda t: t[0])[1], 
+        working_data = detect_peaks(hrdata, rol_mean, min(valid_ma, key=lambda t: t[0])[1],
                                     sample_rate, update_dict=True, working_data=working_data)
         return working_data
     else:
@@ -322,7 +322,7 @@ def check_peaks(rr_arr, peaklist, ybeat, quotient_filter=False, reject_segmentwi
         list or array containing detected peak positions
 
     ybeat : 1d array or list
-        list or array containing corresponding signal values at 
+        list or array containing corresponding signal values at
         detected peak positions. Used for plotting functionality
         later on.
 
@@ -352,15 +352,15 @@ def check_peaks(rr_arr, peaklist, ybeat, quotient_filter=False, reject_segmentwi
     mean_rr = np.mean(rr_arr)
     upper_threshold = mean_rr + 300 if (0.3 * mean_rr) <= 300 else mean_rr + (0.3 * mean_rr)
     lower_threshold = mean_rr - 300 if (0.3 * mean_rr) <= 300 else mean_rr - (0.3 * mean_rr)
-    
+
     working_data['removed_beats'] = peaklist[np.where((rr_arr <= lower_threshold) |
                                                       (rr_arr >= upper_threshold))[0]+1]
     working_data['removed_beats_y'] = ybeat[np.where((rr_arr <= lower_threshold) |
                                                      (rr_arr >= upper_threshold))[0]+1]
-    working_data['binary_peaklist'] = np.asarray([0 if x in working_data['removed_beats'] 
+    working_data['binary_peaklist'] = np.asarray([0 if x in working_data['removed_beats']
                                                   else 1 for x in peaklist])
 
-    if reject_segmentwise: 
+    if reject_segmentwise:
         working_data = check_binary_quality(peaklist, working_data['binary_peaklist'],
                                             working_data=working_data)
 
@@ -369,12 +369,12 @@ def check_peaks(rr_arr, peaklist, ybeat, quotient_filter=False, reject_segmentwi
 
 
 def check_binary_quality(peaklist, binary_peaklist, maxrejects=3, working_data={}):
-    '''checks signal in chunks of 10 beats. 
-    
-    Function that checks signal in chunks of 10 beats. It zeros out chunk if 
-    number of rejected peaks > maxrejects. Also marks rejected segment coordinates 
+    '''checks signal in chunks of 10 beats.
+
+    Function that checks signal in chunks of 10 beats. It zeros out chunk if
+    number of rejected peaks > maxrejects. Also marks rejected segment coordinates
     in tuples (x[0], x[1] in working_data['rejected_segments']
-    
+
     Parameters
     ----------
     peaklist : 1d array or list
@@ -384,7 +384,7 @@ def check_binary_quality(peaklist, binary_peaklist, maxrejects=3, working_data={
         list or array containing mask for peaklist, coding which peaks are rejected
 
     maxjerects : int
-        maximum number of rejected peaks per 10-beat window 
+        maximum number of rejected peaks per 10-beat window
         default : 3
 
     working_data : dict
@@ -408,7 +408,7 @@ def check_binary_quality(peaklist, binary_peaklist, maxrejects=3, working_data={
     >>> wd['rejected_segments']
     [(30, 220)]
 
-    The whole segment is rejected as it contains more than the specified 3 rejections 
+    The whole segment is rejected as it contains more than the specified 3 rejections
     per 10 beats.
     '''
     idx = 0
@@ -416,7 +416,7 @@ def check_binary_quality(peaklist, binary_peaklist, maxrejects=3, working_data={
     for i in range(int(len(binary_peaklist) / 10)):
         if np.bincount(binary_peaklist[idx:idx + 10])[0] > maxrejects:
             binary_peaklist[idx:idx + 10] = [0 for i in range(len(binary_peaklist[idx:idx+10]))]
-            if idx + 10 < len(peaklist): 
+            if idx + 10 < len(peaklist):
                 working_data['rejected_segments'].append((peaklist[idx], peaklist[idx + 10]))
             else:
                 working_data['rejected_segments'].append((peaklist[idx], peaklist[-1]))
@@ -433,17 +433,17 @@ def interpolate_peaks(data, peaks, sample_rate, desired_sample_rate=1000.0, work
 
     Parameters
     ----------
-    data : 1d list or array 
+    data : 1d list or array
         list or array containing heart rate data
 
-    peaks : 1d list or array 
+    peaks : 1d list or array
         list or array containing x-positions of peaks in signal
-    
+
     sample_rate : int or float
         the sample rate of the signal (in Hz)
 
     desired_sampled-rate : int or float
-        the sample rate to which to upsample. 
+        the sample rate to which to upsample.
         Must be sample_rate < desired_sample_rate
 
     Returns
@@ -461,11 +461,11 @@ def interpolate_peaks(data, peaks, sample_rate, desired_sample_rate=1000.0, work
     >>> wd['peaklist'][0:5]
     [63, 165, 264, 360, 460]
 
-    Now, the resolution is at max 10ms as that's the distance between data points. 
+    Now, the resolution is at max 10ms as that's the distance between data points.
     We can use the high precision mode for example to approximate a more precise
     position, for example if we had recorded at 1000Hz:
-    
-    >>> wd = interpolate_peaks(data = data, peaks = wd['peaklist'], 
+
+    >>> wd = interpolate_peaks(data = data, peaks = wd['peaklist'],
     ... sample_rate = 100.0, desired_sample_rate = 1000.0, working_data = wd)
     >>> wd['peaklist'][0:5]
     [63.5, 165.4, 263.6, 360.4, 460.2]
@@ -475,7 +475,7 @@ def interpolate_peaks(data, peaks, sample_rate, desired_sample_rate=1000.0, work
     '''
     assert desired_sample_rate > sample_rate, "desired sample rate is lower than actual sample rate \
 this would result in downsampling which will hurt accuracy."
-    
+
     num_samples = int(0.1 * sample_rate)
     ratio = sample_rate / desired_sample_rate
     interpolation_slices = [(x - num_samples, x + num_samples) for x in peaks]

--- a/heartpy/visualizeutils.py
+++ b/heartpy/visualizeutils.py
@@ -57,16 +57,16 @@ def plotter(working_data, measures, show=True, title='Heart Rate Signal Peak Det
     >>> import heartpy as hp
     >>> data, _ = hp.load_exampledata(0)
     >>> wd, m = hp.process(data, 100.0)
-    
+
     Then we can visualise
 
     >>> plot_object = plotter(wd, m, show=False, title='some awesome title')
 
-    This returns a plot object which can be visualized or saved or appended. 
+    This returns a plot object which can be visualized or saved or appended.
     See matplotlib API for more information on how to do this.
-    
-    A matplotlib plotting object is returned. This can be further processed and saved 
-    to a file. 
+
+    A matplotlib plotting object is returned. This can be further processed and saved
+    to a file.
 
     '''
     #get color palette
@@ -82,7 +82,7 @@ def plotter(working_data, measures, show=True, title='Heart Rate Signal Peak Det
         plt.plot(working_data['rolling_mean'], color='gray', alpha=0.5)
     plt.scatter(peaklist, ybeat, color=colorpalette[1], label='BPM:%.2f' %(measures['bpm']))
     plt.scatter(rejectedpeaks, rejectedpeaks_y, color=colorpalette[2], label='rejected peaks')
-    
+
     #check if rejected segment detection is on and has rejected segments
     try:
         if len(working_data['rejected_segments']) >= 1:
@@ -100,10 +100,10 @@ def plotter(working_data, measures, show=True, title='Heart Rate Signal Peak Det
 def segment_plotter(working_data, measures, title='Heart Rate Signal Peak Detection',
                     figsize=(6, 6), path='', start=0, end=None, step=1): # pragma: no cover
     '''plots analysis results
-   
+
     Function that plots the results of segmentwise processing of heart rate signal
     and writes all results to separate files at the path provided.
-    
+
     Parameters
     ----------
     working_data : dict
@@ -113,7 +113,7 @@ def segment_plotter(working_data, measures, title='Heart Rate Signal Peak Detect
     measures : dict
         dictionary object used by heartpy to store computed measures. Will be created
         if not passed to function
-        
+
     title : str
         the title used in the plot
 
@@ -129,7 +129,7 @@ def segment_plotter(working_data, measures, title='Heart Rate Signal Peak Detect
 
     end : int
         last segment to plot. Must be smaller than total number of segments
-        default : None, will plot until end 
+        default : None, will plot until end
 
     step : int
         stepsize used when iterating over plots every step'th segment will be plotted
@@ -145,21 +145,21 @@ def segment_plotter(working_data, measures, title='Heart Rate Signal Peak Detect
     '''
     #sanity check
     assert 0 < step < len(working_data['hr']), 'step must be larger than zero and smaller than total number of segments'
-    
+
     #set endpoint if not explicitly defined
     if end == None:
         end = len(working_data['hr'])
     else:
         #make sure it is defined within boundary conditions
         assert end <= len(working_data['hr']), 'defined "end" endpoint is larger than number of segments'
-    
+
     #add trailing path slash if user omitted it
     if not (path.endswith('/') or path.endswith('\\')) and len(path) > 0:
         path += '/'
         #create path if it doesn't exist
         if not os.path.isdir(path):
             os.makedirs(path)
-    
+
     #make plots
     filenum = 0
     for i in range(start, end, step):
@@ -201,7 +201,7 @@ def plot_poincare(working_data, measures, show = True,
     measures : dict
         dictionary object used by heartpy to store computed measures. Will be created
         if not passed to function
-        
+
     show : bool
         whether to show the plot right away, or return a matplotlib object for
         further manipulation
@@ -218,7 +218,7 @@ def plot_poincare(working_data, measures, show = True,
     --------
     This function has no examples. See documentation of heartpy for more info.
     '''
-    
+
     #get color palette
     colorpalette = config.get_colorpalette_poincare()
 
@@ -232,7 +232,7 @@ def plot_poincare(working_data, measures, show = True,
     fig, ax = plt.subplots(subplot_kw={'aspect': 'equal'})
 
     #plot scatter
-    plt.scatter(x_plus, x_minus, color = colorpalette[0], 
+    plt.scatter(x_plus, x_minus, color = colorpalette[0],
                 alpha = 0.75, label = 'peak-peak intervals')
 
     #plot identity line
@@ -247,11 +247,11 @@ def plot_poincare(working_data, measures, show = True,
     sd2_xrot, sd2_yrot = rotate_vec(0, sd2, 45)
 
     #plot rotated SD1, SD2 lines
-    plt.plot([np.mean(x_plus), np.mean(x_plus) + sd1_xrot], 
-             [np.mean(x_minus), np.mean(x_minus) + sd1_yrot], 
+    plt.plot([np.mean(x_plus), np.mean(x_plus) + sd1_xrot],
+             [np.mean(x_minus), np.mean(x_minus) + sd1_yrot],
              color = colorpalette[1], label = 'SD1')
-    plt.plot([np.mean(x_plus), np.mean(x_plus) - sd2_xrot], 
-             [np.mean(x_minus), np.mean(x_minus) + sd2_yrot], 
+    plt.plot([np.mean(x_plus), np.mean(x_plus) - sd2_xrot],
+             [np.mean(x_minus), np.mean(x_minus) + sd2_yrot],
              color = colorpalette[2], label = 'SD2')
 
     #plot ellipse
@@ -261,7 +261,7 @@ def plot_poincare(working_data, measures, show = True,
     ax.add_artist(el)
     el.set_edgecolor((0,0,0))
     el.fill = False
-    
+
     plt.legend(loc=4, framealpha=0.6)
     plt.title(title)
 
@@ -314,7 +314,7 @@ def rotate_vec(x, y, angle):
 
     x_rot = (x * cs) - (y * sn)
     y_rot = (x * sn) + (y * cs)
-    
+
     return x_rot, y_rot
 
 
@@ -333,7 +333,7 @@ def plot_breathing(working_data, measures, show=True): # pragma: no cover
     measures : dict
         dictionary object used by heartpy to store computed measures. Will be created
         if not passed to function
-        
+
     show : bool
         whether to show the plot right away, or return a matplotlib object for
         further manipulation


### PR DESCRIPTION
These changes were made because I was troubleshooting why the moving-average algorithm was not working well with my data (lots of very low peaks, most of which were rejected by check_peaks). Ultimately the problem was that the signal was roughly mean-zero, so the moving average threshold was very low, even at 300% augmentation in the algorithm. I put in a check for this (l. 271 of hearpy.py) to make sure the data does not have many negative values.

Along the way, I made a few other suggested changes:
- quotient_filter was no longer used in check_peaks, so it was removed from the arguments
- when rolling average is filling in the missing values at the margins of the data, use the marginal values instead of the overall mean
- tweaks and comments for readability in peakdetection.py