### PR TITLE
Fixed bug when rr_list <= 1 in calc_fd_measurements

### DIFF
--- a/heartpy/analysis.py
+++ b/heartpy/analysis.py
@@ -502,6 +502,12 @@ def calc_fd_measures(method='welch', welch_wsize=240, square_spectrum=False, mea
         measures['lf'] = np.nan
         measures['hf'] = np.nan
         measures['lf/hf'] = np.nan
+        measures['p_total'] = np.nan
+        measures['vlf_perc'] = np.nan
+        measures['lf_perc'] = np.nan
+        measures['hf_perc'] = np.nan
+        measures['lf_nu'] = np.nan
+        measures['hf_nu'] = np.nan
         return working_data, measures
     elif np.sum(rr_list) <= 300000:   # pragma: no cover
         # warn if signal is short


### PR DESCRIPTION
When computing calc_fd_measurements, and rr_list <= 1, and you are expecting measures['p_total'], the "perc" measures or the "nu" measures, it was failing. 

Now, it works for my tests and evaluation project:
![Screenshot from 2021-03-28 19-58-09](https://user-images.githubusercontent.com/9532966/112760563-17e1b600-9000-11eb-9db6-3bcac405d8c4.png)
