### PR TITLE
working_data['peaklist'] is always np.array

### DIFF
--- a/heartpy/analysis.py
+++ b/heartpy/analysis.py
@@ -71,8 +71,8 @@ def calc_rr(peaklist, sample_rate, working_data={}):
     if len(peaklist) > 0:
         if peaklist[0] <= ((sample_rate / 1000.0) * 150):
             peaklist = np.delete(peaklist, 0)
-            working_data['peaklist'] = peaklist
             working_data['ybeat'] = np.delete(working_data['ybeat'], 0)
+    working_data['peaklist'] = peaklist # Make sure, peaklist is always an np.array
 
     rr_list = (np.diff(peaklist) / sample_rate) * 1000.0
     rr_indices = [(peaklist[i], peaklist[i+1]) for i in range(len(peaklist) - 1)]

--- a/heartpy/analysis.py
+++ b/heartpy/analysis.py
@@ -132,7 +132,7 @@ def update_rr(working_data={}):
     This will have generated a corrected RR_list object in the dictionary:
 
     >>> wd['RR_list_cor']
-    [800.0, 1250.0, 1140.0]
+    array([ 800., 1250., 1140.])
 
     As well as updated the lists RR_diff (differences between adjacent peak-peak intervals) and
     RR_sqdiff (squared differences between adjacent peak-peak intervals).

--- a/heartpy/analysis.py
+++ b/heartpy/analysis.py
@@ -139,8 +139,8 @@ def update_rr(working_data={}):
     '''
     rr_source = working_data['RR_list']
     b_peaklist = working_data['binary_peaklist']
-    rr_list = [rr_source[i] for i in range(len(rr_source)) if b_peaklist[i] + b_peaklist[i+1] == 2]
-    rr_mask = [0 if (b_peaklist[i] + b_peaklist[i+1] == 2) else 1 for i in range(len(rr_source))]
+    rr_list = np.array([rr_source[i] for i in range(len(rr_source)) if b_peaklist[i] + b_peaklist[i+1] == 2])
+    rr_mask = np.array([0 if (b_peaklist[i] + b_peaklist[i+1] == 2) else 1 for i in range(len(rr_source))])
     rr_masked = np.ma.array(rr_source, mask=rr_mask)
     rr_diff = np.abs(np.diff(rr_masked))
     rr_diff = rr_diff[~rr_diff.mask]

--- a/heartpy/peakdetection.py
+++ b/heartpy/peakdetection.py
@@ -174,7 +174,7 @@ def detect_peaks(hrdata, rol_mean, ma_perc, sample_rate, update_dict=True, worki
     at the first five peak positions:
 
     >>> wd['peaklist'][0:5]
-    [63, 165, 264, 360, 460]
+    array([ 63, 165, 264, 360, 460], dtype=int64)
     '''
     rmean = np.array(rol_mean)
 
@@ -272,7 +272,7 @@ def fit_peaks(hrdata, rol_mean, sample_rate, bpmmin=40, bpmmax=180, working_data
     To illustrate, these are the first five detected peaks:
 
     >>> wd['peaklist'][0:5]
-    [63, 165, 264, 360, 460]
+    array([ 63, 165, 264, 360, 460], dtype=int64)
 
     and the corresponding peak-peak intervals:
 
@@ -468,9 +468,9 @@ def interpolate_peaks(data, peaks, sample_rate, desired_sample_rate=1000.0, work
 
     >>> import heartpy as hp
     >>> data, _ = hp.load_exampledata(0)
-    >>> wd, m = hp.process(data, 100.0)
+    >>> wd, m = process(data, 100.0)
     >>> wd['peaklist'][0:5]
-    [63, 165, 264, 360, 460]
+    array([ 63, 165, 264, 360, 460], dtype=int64)
 
     Now, the resolution is at max 10ms as that's the distance between data points.
     We can use the high precision mode for example to approximate a more precise
@@ -479,7 +479,7 @@ def interpolate_peaks(data, peaks, sample_rate, desired_sample_rate=1000.0, work
     >>> wd = interpolate_peaks(data = data, peaks = wd['peaklist'],
     ... sample_rate = 100.0, desired_sample_rate = 1000.0, working_data = wd)
     >>> wd['peaklist'][0:5]
-    [63.5, 165.4, 263.6, 360.4, 460.2]
+    array([ 63.5, 165.4, 263.6, 360.4, 460.2])
 
     As you can see the accuracy of peak positions has increased.
     Note that you cannot magically upsample nothing into something. Be reasonable.
@@ -498,6 +498,6 @@ this would result in downsampling which will hurt accuracy."
         peakpos = np.argmax(resampled)
         peaks.append((i[0] + (peakpos * ratio)))
 
-    working_data['peaklist'] = peaks
+    working_data['peaklist'] = np.asarray(peaks)
 
     return working_data


### PR DESCRIPTION
Usually `working_data['peaklist']` is returned as a list. However, if there is a peak in the first 150ms of the trace, it is removed in `calc_rr()`. As a result of this, `working_data['peaklist']` is overwritten by an np.array.

First commit always overwrites `working_data['peaklist']` with np.array which is consistent with most other values in `working_data`. 
Second commit is more optional: It also converts `RR_masklist` and `RR_list_cor` into np.array for consistency. Only `RR_indices` remains a list of tuples.

Fixes #82 