### PR TITLE
Rolling mean offsetter

### DIFF
--- a/heartpy/heartpy.py
+++ b/heartpy/heartpy.py
@@ -276,11 +276,6 @@ include an index column?'
         hrdata = enhance_peaks(hrdata)
         hrdata = hampel_correcter(hrdata, sample_rate)
 
-    # check that the data has positive baseline for the moving average algorithm to work
-    bl_val = np.percentile(hrdata, 0.1)
-    if bl_val < 0:
-        hrdata = hrdata + abs(bl_val)
-
     working_data['hr'] = hrdata
     working_data['sample_rate'] = sample_rate
 

--- a/heartpy/peakdetection.py
+++ b/heartpy/peakdetection.py
@@ -179,7 +179,7 @@ def detect_peaks(hrdata, rol_mean, ma_perc, sample_rate, update_dict=True, worki
     rmean = np.array(rol_mean)
 
     #rol_mean = rmean + ((rmean / 100) * ma_perc)
-    mn = np.mean(rmean / 100) * ma_perc
+    mn = np.std(hrdata)*4*ma_perc/100 
     rol_mean = rmean + mn
 
     peaksx = np.where((hrdata > rol_mean))[0]
@@ -281,7 +281,7 @@ def fit_peaks(hrdata, rol_mean, sample_rate, bpmmin=40, bpmmax=180, working_data
     '''
 
     # moving average values to test
-    ma_perc_list = [-100, -90, -80, -70, -60, -50, -40, -30, -25, -20, -15, -10, -5, 0, 5, 10, 15, 20, 25, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 150, 200, 300]
+    ma_perc_list = [-50, -40, -30, -25, -20, -15, -10, -5, 0, 5, 10, 15, 20, 25, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 150, 200, 300]
 
     rrsd = []
     valid_ma = []

--- a/heartpy/peakdetection.py
+++ b/heartpy/peakdetection.py
@@ -263,10 +263,10 @@ def fit_peaks(hrdata, rol_mean, sample_rate, bpmmin=40, bpmmax=180, working_data
     Now the wd dict contains the best fit paramater(s):
 
     >>> wd['best']
-    20
+    25
 
     This indicates the best fit can be obtained by raising the moving average
-    with 20%.
+    with 25% of the standard deviation of the signal.
 
     The results of the peak detection using these parameters are included too.
     To illustrate, these are the first five detected peaks:

--- a/heartpy/peakdetection.py
+++ b/heartpy/peakdetection.py
@@ -281,7 +281,7 @@ def fit_peaks(hrdata, rol_mean, sample_rate, bpmmin=40, bpmmax=180, working_data
     '''
 
     # moving average values to test
-    ma_perc_list = [5, 10, 15, 20, 25, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 150, 200, 300]
+    ma_perc_list = [-100, -90, -80, -70, -60, -50, -40, -30, -25, -20, -15, -10, -5, 0, 5, 10, 15, 20, 25, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 150, 200, 300]
 
     rrsd = []
     valid_ma = []


### PR DESCRIPTION
Fixing #80 by offsetting the rolling mean by a percentage of the standard deviation of the signal, making it DC-component-independent.

Independently, I added negative offsets. Various data that I have tested with suggest that sometimes it is more reliable to detect peaks based on the low points which is essentially what we are doing by moving the rolling average down.
This makes the library a bit slower (not too much but I did not measure). If we want to compensate, we can remove any offset above 70% as this corresponds to an average only 0.3% of all samples lie above.

I chose the base value as 4*std as this seemed to be the closest to the rolling mean, making the results with the included data nearly identical.