### PR TITLE
Fix rolling mean bug and enhance rolling mean calculation

### DIFF
--- a/heartpy/heartpy.py
+++ b/heartpy/heartpy.py
@@ -411,7 +411,7 @@ def process_segmentwise(hrdata, sample_rate, segment_width=120, segment_overlap=
     measures (m) dict now contains a list of that measure for each segment.
 
     >>> [round(x, 1) for x in m['bpm']]
-    [100.0, 96.8, 97.2, 97.9, 97.0, 96.8, 96.8, 95.0, 92.9, 96.7, 99.2]
+    [100.0, 96.8, 97.2, 97.9, 96.7, 96.8, 96.8, 95.0, 92.9, 96.7, 99.2]
 
     Specifying mode = 'fast' will run peak detection once and use detections
     to compute measures over each segment. Useful for speed ups, but typically

--- a/heartpy/peakdetection.py
+++ b/heartpy/peakdetection.py
@@ -165,7 +165,7 @@ def detect_peaks(hrdata, rol_mean, ma_perc, sample_rate, update_dict=True, worki
     it would work like this:
 
     >>> import heartpy as hp
-    >>> from heartpy.datautils import rolling_mean, _sliding_window
+    >>> from heartpy.datautils import rolling_mean
     >>> data, _ = hp.load_exampledata(0)
     >>> rol_mean = rolling_mean(data, windowsize = 0.75, sample_rate = 100.0)
     >>> wd = detect_peaks(data, rol_mean, ma_perc = 20, sample_rate = 100.0)
@@ -252,7 +252,7 @@ def fit_peaks(hrdata, rol_mean, sample_rate, bpmmin=40, bpmmax=180, working_data
     Given included example data let's show how this works
 
     >>> import heartpy as hp
-    >>> from heartpy.datautils import rolling_mean, _sliding_window
+    >>> from heartpy.datautils import rolling_mean
     >>> data, _ = hp.load_exampledata(0)
     >>> rol_mean = rolling_mean(data, windowsize = 0.75, sample_rate = 100.0)
 


### PR DESCRIPTION
Fix #85 (see bug description there)

Instead of a fix, I dumped the whole rolling mean calculation and use `scipy.ndimage.filters.uniform_filter1d` instead which is faster and better (it handles edges well without just copying the neighbouring values). Besides the edge cases, it is fully backwards compatible (I ensured float computation even though you could argue that int would do the job too).

[Considerations regarding efficiency](https://stackoverflow.com/questions/13728392/moving-average-or-running-mean/43200476#43200476)

[Function Doc](https://docs.scipy.org/doc/scipy/reference/generated/scipy.ndimage.uniform_filter1d.html)


